### PR TITLE
Use fedora for original files

### DIFF
--- a/config/install/migrate_plus.migration.islandora_basic_image_files.yml
+++ b/config/install/migrate_plus.migration.islandora_basic_image_files.yml
@@ -29,7 +29,7 @@ source:
   item_selector: /foxml:digitalObject
 
   constants:
-    destination_directory: 'public://masters'
+    destination_directory: 'fedora://masters'
     extension: 'jpg'
     fedora_base_url: *fedora_base_url
     objects_string: 'objects'

--- a/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
+++ b/src/Plugin/migrate_plus/data_parser/AuthenticatedXml.php
@@ -59,4 +59,17 @@ class AuthenticatedXml extends Xml {
 
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * Islandora Source can provide 0 urls, we need to exit or it throws an
+   * error.
+   */
+  protected function nextSource() {
+    if (count($this->urls) == 0) {
+      return FALSE;
+    }
+    return parent::nextSource();
+  }
+
 }


### PR DESCRIPTION
Avoid trying to access an empty array, this just avoids the message getting dumped to the logs. It works either way.