### PR TITLE
Address https://github.com/Islandora-CLAW/CLAW/issues/951.

### DIFF
--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_basic_image.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_basic_image.yml
@@ -99,20 +99,6 @@ process:
       plugin: substr
       source: member_of_collection
       start: 11
-  field_mods_text:
-    -
-      plugin: skip_on_empty
-      method: process
-      source: mods_dsid
-    -
-      plugin: fedora_datastream
-      source: mods_dsid
-      settings:
-        fedora_base_url: 'http://10.0.2.2:18080/fedora'
-        authentication:
-          plugin: basic
-          username: fedoraAdmin
-          password: fedoraAdmin
   field_tags:
     plugin: entity_lookup
     source: constants/image

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_basic_image.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_basic_image.yml
@@ -54,10 +54,6 @@ source:
       name: member_of
       label: 'Member Of'
       selector: 'foxml:datastream[@ID = "RELS-EXT" and @CONTROL_GROUP = "X" ]/foxml:datastreamVersion[position() = last()]/foxml:xmlContent/rdf:RDF/rdf:Description/fedora:isMemberOf/@rdf:resource'
-    -
-      name: mods_dsid
-      label: 'MODS ds'
-      selector: 'foxml:datastream[@ID = "MODS" and @CONTROL_GROUP = "M"]/foxml:datastreamVersion[position() = last()]'
   ids:
     PID:
       type: string


### PR DESCRIPTION
Removes no-longer-used lines from `migrate_plus.migration.islandora_basic_image.yml` related to the destination of the MODS datastream content.

To test:

1. Check out this branch
1. Configure and install the migrate_7x_claw module as usual
1. Run a migration. There should be no side effects.
