### PR TITLE
Reverting to 10.0.2.2

### DIFF
--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_file.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_file.yml
@@ -15,9 +15,9 @@ migration_group: islandora_7x
 label: 'AUDIT File'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"' 
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_media.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_media.yml
@@ -15,8 +15,8 @@ migration_group: islandora_7x
 label: 'AUDIT Media'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic
@@ -31,7 +31,7 @@ source:
     mimetype: application/xml
     extension: xml
     dsid: AUDIT
-    fedora_base_url: 'http://97.107.189.65:8080/fedora'
+    fedora_base_url: 'http://10.0.2.2:8080/fedora'
     creator_uid: 1
     audit_url: http://islandora.ca/audit-trail
   fields:

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_corporate.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_corporate.yml
@@ -15,10 +15,10 @@ migration_group: islandora_7x
 label: 'Islandora Corporate'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'fedora_datastreams_ms:MODS'
   row_type: MODS
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_files.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_files.yml
@@ -15,9 +15,9 @@ migration_group: islandora_7x
 label: 'Islandora Files'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"' 
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   islandora_type: datastreams
   datastream_solr_field: fedora_datastreams_ms
   data_fetcher_plugin: http
@@ -28,7 +28,7 @@ source:
   data_parser_plugin: tuque_datastreams
   item_selector: '/foxml:digitalObject'
   constants:
-    fedora_base_url: 'http://97.107.189.65:8080/fedora'
+    fedora_base_url: 'http://10.0.2.2:8080/fedora'
     destination_directory: 'fedora://'
     extension: jpg
     objects_string: objects

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_geographic.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_geographic.yml
@@ -15,10 +15,10 @@ migration_group: islandora_7x
 label: 'Islandora Geographic'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'fedora_datastreams_ms:MODS'
   row_type: MODS
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_media.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_media.yml
@@ -15,9 +15,9 @@ migration_group: islandora_7x
 label: 'Islandora Media'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"' 
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   islandora_type: datastreams
   datastream_solr_field: fedora_datastreams_ms
   data_fetcher_plugin: http

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_objects.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_objects.yml
@@ -15,10 +15,10 @@ migration_group: islandora_7x
 label: 'Islandora Objects'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"' 
   row_type: solr
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_person.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_person.yml
@@ -15,10 +15,10 @@ migration_group: islandora_7x
 label: 'Islandora Person'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'fedora_datastreams_ms:MODS'
   row_type: MODS
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_subject.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_subject.yml
@@ -15,10 +15,10 @@ migration_group: islandora_7x
 label: 'Islandora Subject'
 source:
   plugin: islandora
-  solr_base_url: 'http://97.107.189.65:8080/solr'
+  solr_base_url: 'http://10.0.2.2:8080/solr'
   q: 'fedora_datastreams_ms:MODS'
   row_type: MODS
-  fedora_base_url: 'http://97.107.189.65:8080/fedora'
+  fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:
     plugin: basic


### PR DESCRIPTION
Part of https://github.com/Islandora-CLAW/CLAW/issues/905 discovered by @rosiel.

I forgot to put the ip back to 10.0.2.2 instead of @mjordan's test server.

FWIW, to do this yourself with your own non-localhost server, issue this command from within the feature directory:
```bash
$ sed -i 's/10\.0\.2\.2/X\.X\.X\.X/' *.yml
``` 