### PR TITLE
Adds a admin page for configuration. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the following content models can be migrated over with full functiona
 If you want some sample Basic Image objects with metadata made from stock forms, check out [this zip
 file](docs/examples/sample_objects.zip) that you can use with `islandora_zip_batch_importer`. All the images were
 obtained from [Pexels](https://www.pexels.com/) and are free to use for personal or business purposes, with the
-original photographers attributed in the MODS. 
+original photographers attributed in the MODS.
 
 ## Installation
 
@@ -33,26 +33,48 @@ Install the module and example migrations at the same time using Drush
 ```
 drush en islandora_migrate_7x_claw_feature
 ```
- 
+
 ## Configuration
 
 By default, the migrations are configured to work with an `islandora_vagrant` instance running on the same host as a
 `claw-playbook` instance, which is convenient for development and testing. But for your Islandora 7.x instance, the
 following config will need to be set the same way on the source plugin of each migration (except for the
-"7.x Tags Migration from CSV" migration):  
+"7.x Tags Migration from CSV" migration):
 
+### Admin page
+__/admin/config/islandora/migrate_7x_claw__
+
+![Screen Shot 2019-11-08 at 12 32 30 PM](https://user-images.githubusercontent.com/2738244/68497994-da6e6400-0223-11ea-8247-d6b3dd117f80.png)
+
+Please read the _Command Line Configuration_ section for input value descriptions and purposes. Once saved you can run the migration groups tasks (admin/structure/migrate/manage/islandora_7x/migrations)
+
+#### Optional:
+To verify saved changes go to admin/config/development/configuration/single/export
+- Configuration type: migration group
+- Configuration Name: Each of the following should reflect the values given.
+  - migrate_plus.migration.islandora_audit_file
+  - migrate_plus.migration.islandora_audit_media
+  - migrate_plus.migration.islandora_corporate
+  - migrate_plus.migration.islandora_files
+  - migrate_plus.migration.islandora_geographic
+  - migrate_plus.migration.islandora_media
+  - migrate_plus.migration.islandora_objects
+  - migrate_plus.migration.islandora_person
+  - migrate_plus.migration.islandora_subject
+
+### Command Line Configuration
 - `solr_base_url` should point to your Islandora 7.x Solr instance (i.e. `http://example.org:8080/solr`)
 - `fedora_base_url` should point to your Fedora 3 instance (i.e. `http://example.org:8080/fedora`)
-- The `username` and `password` for your Fedora 3 instance in the block 
+- The `username` and `password` for your Fedora 3 instance in the block
    ```
     plugin: basic
     username: fedoraAdmin
     password: fedoraAdmin
    ```
-- `q` is used to define a Solr query that selects which objects get migrated.  From a fresh clone, the 
+- `q` is used to define a Solr query that selects which objects get migrated.  From a fresh clone, the
 migrations are configured to look for `islandora:sp_basic_image_collection` and all its children with the following query:
   ```
-    RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection" 
+    RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"
   ```
 You can easily import a collection of your own by changing the PID in the above query, or you can provide your own
 query to migrate over objects in other ways (such as per content model, in order by date created, etc...).  If you can write a Solr select query for it, you can migrate it into Islandora 8.  Omitting `q` from configuration will default to `*:*`
@@ -90,14 +112,14 @@ Clicking **Execute** on "7.x Tags Migration from CSV" migration displays a page 
 
 ![Execute Migration](docs/images/execute_migration.png)
 
-The operations you can run for a migration are 
+The operations you can run for a migration are
 * **Import** - import un-migrated objects (check the "Update" checkbox to re-run previously migrated objects)
 * **Rollback** - delete all the objects (if any) previously imported
 * **Stop** - stop a long running import.
 * **Reset** - reset an import that might have failed.
 
 If you select "Import", and then click "Execute", it will run the migration. It should process 5 items.
-  
+
 Then you can run the "Islandora Media" migration, which depends on the remaining migrations.  Running it effectively
 runs the entire group of migrations other than the "7.x Tags Migration from CSV" migration.  After they're all done,
 you should be able to navigate to the home page of your Islandora 8 instance and see your content brought over from

--- a/config/install/migrate_7x_claw.settings.yml
+++ b/config/install/migrate_7x_claw.settings.yml
@@ -1,0 +1,5 @@
+fedora-endpoint-url: 'http://10.0.2.2:8080/fedora'
+oldfedoraUsername: fedoraAdmin
+oldfedorapsswd: fedoraAdmin
+solr-endpoint-url: 'http://10.0.2.2:8080/solr'
+migrate_7x_claw_solr_q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"'

--- a/migrate_7x_claw.info.yml
+++ b/migrate_7x_claw.info.yml
@@ -6,3 +6,4 @@ core: 8.x
 dependencies:
   - drupal:migrate
   - migrate_plus:migrate_plus
+configure: migrate_7x_claw.settings

--- a/migrate_7x_claw.links.menu.yml
+++ b/migrate_7x_claw.links.menu.yml
@@ -1,0 +1,6 @@
+migrate_7x_claw.settings:
+  title: 'Migration Settings'
+  description: 'Control settings for 7x to 8x migration'
+  route_name: migrate_7x_claw.settings
+  parent: system.admin_config_islandora
+  weight: 10

--- a/migrate_7x_claw.links.menu.yml
+++ b/migrate_7x_claw.links.menu.yml
@@ -1,6 +1,6 @@
 migrate_7x_claw.settings:
-  title: 'Migration Settings'
-  description: 'Control settings for 7x to 8x migration'
+  title: 'Islandora Migration Settings'
+  description: 'Control settings for the 7x to 8x migration module.'
   route_name: migrate_7x_claw.settings
   parent: system.admin_config_islandora
   weight: 10

--- a/migrate_7x_claw.module.php
+++ b/migrate_7x_claw.module.php
@@ -21,9 +21,6 @@ function get_migrate_install() {
     ->set('fedora-endpoint-url', \Drupal::config('migrate_7x_claw.settings')
     ->set('oldfedoraUsername', \Drupal::config('migrate_7x_claw.settings')
     ->set('oldfedorapsswd', \Drupal::config('migrate_7x_claw.settings')
-    ->set('newfedoraUsername', \Drupal::config('migrate_7x_claw.settings')
-    ->set('newfedorapsswd', \Drupal::config('migrate_7x_claw.settings')
-    ->set('sevenx_url', \Drupal::config('migrate_7x_claw.settings')
     ->set('solr-endpoint-url', \Drupal::config('migrate_7x_claw.settings')
     ->set('migrate_7x_claw_solr_q', \Drupal::config('migrate_7x_claw.settings')
     ->save();

--- a/migrate_7x_claw.module.php
+++ b/migrate_7x_claw.module.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Stuff is going on here.
+ */
+
+/**
+ * Get settings.
+ */
+function get_migrate_setting() {
+  return /Drupal::service('migrate_7x_claw.migrate_7x_claw')->getMigrate7xSetting();
+}
+
+/**
+ * Get settings.
+ */
+function get_migrate_install() {
+  /Drupal::configFactory()
+    ->getEditable('migrate_7x_claw.settings')
+    ->set('fedora-endpoint-url', \Drupal::config('migrate_7x_claw.settings')
+    ->set('oldfedoraUsername', \Drupal::config('migrate_7x_claw.settings')
+    ->set('oldfedorapsswd', \Drupal::config('migrate_7x_claw.settings')
+    ->set('newfedoraUsername', \Drupal::config('migrate_7x_claw.settings')
+    ->set('newfedorapsswd', \Drupal::config('migrate_7x_claw.settings')
+    ->set('sevenx_url', \Drupal::config('migrate_7x_claw.settings')
+    ->set('solr-endpoint-url', \Drupal::config('migrate_7x_claw.settings')
+    ->set('migrate_7x_claw_solr_q', \Drupal::config('migrate_7x_claw.settings')
+    ->save();
+}

--- a/migrate_7x_claw.routing.yml
+++ b/migrate_7x_claw.routing.yml
@@ -1,0 +1,9 @@
+migrate_7x_claw.settings:
+  path: '/admin/config/islandora/migrate_7x_claw'
+  defaults:
+    _form: 'Drupal\migrate_7x_claw\Form\MIGRATE7XCLAWSettingsForm'
+    _title: 'Islandora Migration Settings'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE

--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_files.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_files.yml
@@ -16,7 +16,7 @@ label: 'Islandora Files'
 source:
   plugin: islandora
   solr_base_url: 'http://10.0.2.2:8080/solr'
-  q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"' 
+  q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"'
   fedora_base_url: 'http://10.0.2.2:8080/fedora'
   islandora_type: datastreams
   datastream_solr_field: fedora_datastreams_ms
@@ -78,7 +78,8 @@ process:
       text/xml: xml
       application/xml: xml
       application/rdf+xml: xml
-      application/pdf: pdf 
+      application/pdf: pdf
+      application/x-binary: bin
       image/jpeg: jpg
       image/tiff: tiff
       image/tif: tiff
@@ -87,8 +88,8 @@ process:
       image/gif: gif
       image/jp2: jp2
       audio/mpeg: mp3
-      audio/wav: wav 
-      audio/aac: aac 
+      audio/wav: wav
+      audio/aac: aac
       video/mp4: mp4
       video/x-matroska: mkv
       text/plain: txt

--- a/src/Form/MIGRATE7XCLAWSettingsForm.php
+++ b/src/Form/MIGRATE7XCLAWSettingsForm.php
@@ -105,8 +105,10 @@ class MIGRATE7XCLAWSettingsForm extends ConfigFormBase {
     $config->set('fedora-endpoint-url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_audit_file_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_audit_media_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_audit_media_config->set('source.constants.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_corporate_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_files_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_files_config->set('source.constants.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_geographic_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_media_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
     $islandora_objects_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));

--- a/src/Form/MIGRATE7XCLAWSettingsForm.php
+++ b/src/Form/MIGRATE7XCLAWSettingsForm.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\migrate_7x_claw\Form\MIGRATE7XCLAWSettingsForm.
+ */
+
+namespace Drupal\migrate_7x_claw\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines a form to configure migrate_7x_claw module settings.
+ */
+class MIGRATE7XCLAWSettingsForm extends ConfigFormBase {
+  /**
+   * {@interidoc}
+   */
+  public function getFormId() {
+    return 'migrate_7x_claw_settings';
+  }
+
+  /**
+   * {@interitdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'migrate_7x_claw.settings',
+      'migrate_plus.migration.islandora_audit_file',
+      'migrate_plus.migration.islandora_audit_media',
+      'migrate_plus.migration.islandora_corporate',
+      'migrate_plus.migration.islandora_files',
+      'migrate_plus.migration.islandora_geographic',
+      'migrate_plus.migration.islandora_media',
+      'migrate_plus.migration.islandora_objects',
+      'migrate_plus.migration.islandora_person',
+      'migrate_plus.migration.islandora_subject',
+    ];
+  }
+
+  /**
+   * {@interitdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('migrate_7x_claw.settings');
+    $form['migrate_7x_claw_fedoraConfig'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("Islandora 7's Fedora Configuration"),
+    ];
+    $form['migrate_7x_claw_fedoraConfig']['fedora-endpoint-url'] = [
+      '#type' => 'url',
+      '#title' => $this->t("Fedora base URL"),
+      '#default_value' => $config->get('fedora-endpoint-url'),
+      '#required' => TRUE,
+    ];
+    $form['migrate_7x_claw_fedoraConfig']['oldfedoraUsername'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Fedora Username'),
+      '#default_value' => $config->get('oldfedoraUsername'),
+      '#required' => TRUE,
+    ];
+    $form['migrate_7x_claw_fedoraConfig']['oldfedorapsswd'] = [
+      '#type' => 'password',
+      '#title' => $this->t("Fedora User's password."),
+      '#suffix' => $this->t('Leave blank to use previously save password.'),
+      '#default_value' => $config->get('oldfedorapsswd'),
+    ];
+    $form['migrate_7x_claw_solrConfig'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t("Islandora 7's Solr Configuration"),
+    ];
+    $form['migrate_7x_claw_solrConfig']['solr-endpoint-url'] = [
+      '#type' => 'url',
+      '#title' => $this->t("Solr base URL"),
+      '#default_value' => $config->get('solr-endpoint-url'),
+      '#required' => TRUE,
+    ];
+    $form['migrate_7x_claw_solrConfig']['migrate_7x_claw_solr_q'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Solr query'),
+      '#default_value' => $config->get('migrate_7x_claw_solr_q'),
+      '#size' => 160,
+      '#maxlength' => 1240,
+      '#required' => TRUE,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@interitdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $islandora_audit_file_config = $this->config('migrate_plus.migration.islandora_audit_file');
+    $islandora_audit_media_config = $this->config('migrate_plus.migration.islandora_audit_media');
+    $islandora_corporate_config = $this->config('migrate_plus.migration.islandora_corporate');
+    $islandora_files_config = $this->config('migrate_plus.migration.islandora_files');
+    $islandora_geographic_config = $this->config('migrate_plus.migration.islandora_geographic');
+    $islandora_media_config = $this->config('migrate_plus.migration.islandora_media');
+    $islandora_objects_config = $this->config('migrate_plus.migration.islandora_objects');
+    $islandora_person_config = $this->config('migrate_plus.migration.islandora_person');
+    $islandora_subject_config = $this->config('migrate_plus.migration.islandora_subject');
+    $config = $this->config('migrate_7x_claw.settings');
+
+    $config->set('fedora-endpoint-url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_audit_file_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_audit_media_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_corporate_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_files_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_geographic_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_media_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_objects_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_person_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+    $islandora_subject_config->set('source.fedora_base_url', $form_state->getValue('fedora-endpoint-url'));
+
+    $config->set('oldfedoraUsername', $form_state->getValue('oldfedoraUsername'));
+    $islandora_audit_file_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_audit_media_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_corporate_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_files_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_geographic_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_media_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_objects_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_person_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_subject_config->set('source.authentication.username', $form_state->getValue('oldfedoraUsername'));
+    $islandora_files_config->set('process.uri.settings.authentication.username', $form_state->getValue('oldfedoraUsername'));
+
+    if (!$form_state->getValue('oldfedorapsswd') == '') {
+      $config->set('oldfedorapsswd', $form_state->getValue('oldfedorapsswd'));
+      $islandora_audit_file_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_audit_media_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_corporate_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_files_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_geographic_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_media_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_objects_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_person_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_subject_config->set('source.authentication.password', $form_state->getValue('oldfedorapsswd'));
+      $islandora_files_config->set('process.uri.settings.authentication.password', $form_state->getValue('oldfedorapsswd'));
+    }
+
+    $config->set('solr-endpoint-url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_audit_file_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_audit_media_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_corporate_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_files_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_geographic_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_media_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_objects_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_person_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+    $islandora_subject_config->set('source.solr_base_url', $form_state->getValue('solr-endpoint-url'));
+
+    $config->set('migrate_7x_claw_solr_q', $form_state->getValue('migrate_7x_claw_solr_q'));
+    $islandora_audit_file_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
+    $islandora_files_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
+    $islandora_media_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
+    $islandora_objects_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
+
+    $config->save();
+    $islandora_audit_file_config->save();
+    $islandora_audit_media_config->save();
+    $islandora_corporate_config->save();
+    $islandora_files_config->save();
+    $islandora_geographic_config->save();
+    $islandora_media_config->save();
+    $islandora_objects_config->save();
+    $islandora_person_config->save();
+    $islandora_subject_config->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1323

# What does this Pull Request do?
Adds a admin page for the migrate 7x migration

# What's new?
Admin page /admin/config/islandora/migrate_7x_claw
Adds a menu item in the configuration dropdown.
Modifies the values stored in Drupal for the migration plus submodule (solr URL, fedora credentials & location). 

# How should this be tested?
Prior to pulling this PR go to the single export page to verify values saved reflect the original defaults.  (admin/config/development/configuration/single/export)
To view each of these. Take note of the solr/fedora URLs and fedora username/password (and the URI fedora username/password if it has one).
- Configuration type: migration group
- Configuration Name: Each of the following should reflect the values given.
  - migrate_plus.migration.islandora_audit_file
  - migrate_plus.migration.islandora_audit_media
  - migrate_plus.migration.islandora_corporate
  - migrate_plus.migration.islandora_files
  - migrate_plus.migration.islandora_geographic
  - migrate_plus.migration.islandora_media
  - migrate_plus.migration.islandora_objects
  - migrate_plus.migration.islandora_person
  - migrate_plus.migration.islandora_subject

Trigger a migration to see if everything works before continuing. 

---
### To change to this pull request code:
```shell
# disable and remove the module

$ drush -y pmu migrate_7x_claw
$ cd /var/www/html/drupal/web/modules/contrib/
$ rm -rf migrate_7x_claw

$ git clone https://github.com/Islandora-Devops/migrate_7x_claw
$ cd migrate_7x_claw
$ git fetch origin pull/27/head:pr-27
$ git checkout pr-27

# installer function adds values needed. This is an important step. 
$ cd /var/www/html/drupal
$ drush -y en migrate_7x
$ drush -y en islandora_migrate_7x_claw_feature
$ sudo chown -R www-data:www-data /var/www/html/drupal/web/modules/contrib/migrate_7x_claw
$ drush cr
```


### Verify Documentation gives the proper instructions
Follow the added steps in the README (basically change the values and click save). 
Go back to previous steps to read/export the single values to verify they now reflect the values placed into the migrate 7x configuration page

### Last Step:
Go to http://localhost:8000/admin/structure/migrate  > Islandora Objects > List Migrations
and import all changes. 

Test a migration like previous steps with the values to verify it's using the values saved in the admin UI and not just defaulting to the defaults.

# Additional Notes:
N/A

# Interested parties
@dannylamb @Islandora-Devops/committers
