### PR TITLE
Added note to README about disabling the 'Technical Metadata on inges…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ From there, you can select all changes and clicking "Import Changes"
 
 ![Import Changes](docs/images/feature_import_changes.png)
 
+### Additional configuration
+
+`TECHMD` datastreams from the source Islandora 7.x are migrated automatically and are added as media. However, by default Islandora 8 also generates a "FITS Technical Metadata" media file for each "Original File" ingested or migrated. The 7.x `TECHMD` datastream and the FITS Technical Metadata file are basically identical. In order to prevent Islandora 8 from generating this redundant FITS output on migration, you should disable the Context that triggers the creation of the FITS Technical Metadata file prior to running your migration.
+
+To do this, in your Islandora 8 site, go to Admin > Structure > Context and disable the "Technical Metadata on ingest" Context. Once your migration is over, re-enable it.
+
+
 ## Running the migrations
 
 You can quickly run all migrations using `drush`:


### PR DESCRIPTION
…t' Context during migrations.

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1246#issuecomment-581999629

# What does this Pull Request do?

Adds an "Additional configuration" section to the README that describes why it is a good idea to disable the "Technical Metadata on ingest" Context during migrations from 7.x.

# What's new?

A new section titled "Additional configuration", and some text in it as above.

# How should this be tested?

Read it for clarity and completeness.


# Interested parties
@Islandora-Devops/committers @ajstanley 
