### PR TITLE
Add missing query field to AUDIT Media.

### DIFF
--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_media.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_audit_media.yml
@@ -16,6 +16,7 @@ label: 'AUDIT Media'
 source:
   plugin: islandora
   solr_base_url: 'http://10.0.2.2:8080/solr'
+  q: 'RELS_EXT_isMemberOfCollection_uri_ms:"info:fedora/islandora:sp_basic_image_collection" OR PID:"islandora:sp_basic_image_collection"'
   fedora_base_url: 'http://10.0.2.2:8080/fedora'
   data_fetcher_plugin: http
   authentication:

--- a/src/Form/MIGRATE7XCLAWSettingsForm.php
+++ b/src/Form/MIGRATE7XCLAWSettingsForm.php
@@ -154,6 +154,7 @@ class MIGRATE7XCLAWSettingsForm extends ConfigFormBase {
 
     $config->set('migrate_7x_claw_solr_q', $form_state->getValue('migrate_7x_claw_solr_q'));
     $islandora_audit_file_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
+    $islandora_audit_media_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
     $islandora_files_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
     $islandora_media_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));
     $islandora_objects_config->set('source.q', $form_state->getValue('migrate_7x_claw_solr_q'));


### PR DESCRIPTION
**GitHub Issue**: None at the moment. I can create one though if need be.

(Came about via Slack discussion).

# What does this Pull Request do?

Add missing query field to AUDIT Media. If it is missing, the AUDIT Media migration will try to migrate whatever the default Solr query of the instance it is coming from is. Which can be `*:*` :scream: 

# How should this be tested?

Run a new migration with this.

