### PR TITLE
Fix for batches which do not return a result from the dataparser in t…

### DIFF
--- a/src/Plugin/migrate/source/Islandora.php
+++ b/src/Plugin/migrate/source/Islandora.php
@@ -199,6 +199,20 @@ class Islandora extends SourcePluginExtension {
   /**
    * {@inheritdoc}
    */
+  public function rewind() {
+    parent::rewind();
+    // Due to the batching approach we need to have find the first batch with
+    // an actual result, otherwise the caller will assume that the results 
+    // have been exhausted. Go until we are on the last batch.
+    while (!$this->getIterator()->valid() && ($this->count - ($this->batchCounter * $this->batchSize) > $this->batchSize)) {
+      $this->fetchNextBatch();
+      $this->next();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function doCount() {
     if (is_null($this->count)) {
       if ($this->processing == self::DATASTREAM_TYPE) {


### PR DESCRIPTION
…he first batch.

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1516

# What does this Pull Request do?

Overrides the `rewind()` function of the `SourceBasePlugin` extended class to be aware of batches.

# What's new?

Function in question will iterate through batches until a valid starting point is found, otherwise it will exhaust all batches and exit as expect.

# How should this be tested?

**Steps to reproduce:**

1. Create a migration (see the example below).
2. Make sure that it will match against the given query, but will not be in the first 10 results of the query.
3. Run the migration.
4. Note that no taxonomy terms were created.

_If using the code from this branch the taxonomy terms should be created as expected._

```
langcode: en
status: true
dependencies:
  enforced:
    module:
      - migrate_7x_claw
      - migrate_plus
      - islandora
id: islandora_untyped_name
class: null
field_plugin_method: null
cck_plugin_method: null
migration_tags: null
migration_group: islandora_7x
label: 'Islandora Untyped Name'
source:
  plugin: islandora
  solr_base_url: 'http://localhost:9999/solr'
  q: 'fedora_datastreams_ms:MODS'
  row_type: MODS
  fedora_base_url: 'http://localhost:8080/fedora'
  data_fetcher_plugin: http
  authentication:
    plugin: basic
    username: fedoraAdmin
    password: fedoraAdmin
  data_parser_plugin: authenticated_xml
  item_selector: '/mods:mods/mods:name[@type = "" or not(@type)]'
  constants:
    creator_uid: 1
  fields:
    -
      name: name
      label: Name
      selector: 'mods:namePart'
  ids:
    name:
      type: string
process:
  name: name
destination:
  plugin: 'entity:taxonomy_term'
  default_bundle: untyped_name
migration_dependencies:
  required: {  }
  optional: {  }
```