### PR TITLE
Change tags migration to 3.x syntax.

### DIFF
--- a/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_7x_tags.yml
+++ b/modules/islandora_migrate_7x_claw_feature/config/install/migrate_plus.migration.islandora_7x_tags.yml
@@ -14,8 +14,8 @@ label: '7.x Tags Migration from CSV'
 source:
   plugin: csv
   path: modules/contrib/migrate_7x_claw/migrate/tags.csv
-  header_row_count: 1
-  keys:
+  header_offset: 0
+  ids:
     - external_uri
 process:
   name: name


### PR DESCRIPTION
**GitHub Issue**: #38 

# What does this Pull Request do?

Updates the tags migration to use the 3x syntax (in place since 2019) for the migrate source CSV module. See https://www.drupal.org/node/3060246 for more details.

# What's new?
* renames `keys` to `ids`
* changes `header row count` to `header_offset`
* Does this change require documentation to be updated? No, this fixes an annoying bug. 
* Does this change add any new dependencies? changes to require the 3x. 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

To reproduce:
Install Migrate 7x Claw and run the tags migration. You will get 1 tag, instead of the 6 in the CSV.
Load these changes to the feature, and you should get all 6 tags migrated. 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag unsure, @Islandora-Devops/committers
