### PR TITLE
Update codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^6",
-    "squizlabs/php_codesniffer": "2.7.1",
+    "squizlabs/php_codesniffer": "2.8.1",
     "drupal/coder": "*",
     "sebastian/phpcpd": "*"
   },


### PR DESCRIPTION
**GitHub Issue**: [(link)](https://github.com/Islandora-Devops/migrate_7x_claw/security/dependabot/1) (dependabot alert may or may not be visible.)

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Uses of shell_exec() and exec() were not escaping filenames and configuration settings in most cases
applies to <2.8.1, fixed in 2.8.1


# What's new?

Use patched version of php_codesniffer.

# How should this be tested?

Does codesniffer still work/run? (not sure how to test tbh)

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
